### PR TITLE
Fix V677 warning from PVS-Studio Static Analyzer

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,9 +3,9 @@
  */
 #include <avr/interrupt.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "gdb.h"
 
-typedef uint16_t size_t;
 typedef uint32_t u32;
 
 static void u32_swap(void *a, void *b, int size)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
V677 Custom declaration of a standard 'size_t' type. The declaration from system header files should be used instead. main.c:8