### PR TITLE
Add Atmega32U4 support

### DIFF
--- a/factorial.c
+++ b/factorial.c
@@ -1,0 +1,20 @@
+#include <avr/interrupt.h> // sei()
+#include "gdb.h"
+
+int fact(int n)
+{volatile int __attribute__((unused)) tmp=n; // stack
+ if (n>1)
+    return(fact(n-1)*n);
+ else return(1); // 1!=1
+}
+
+int main(void)
+{
+ volatile int __attribute__((unused)) val=5,res;
+ volatile __attribute__((unused)) static int val1=0x42,val2=0x55; // heap
+ struct gdb_context ctx;
+ gdb_init(&ctx);
+ sei();
+ while(1)
+    res=fact(val);
+}

--- a/main.c
+++ b/main.c
@@ -1,20 +1,117 @@
-#include <avr/interrupt.h> // sei()
+/*
+ * Sort algorithm and its test from linux kernel
+ */
+#include <avr/interrupt.h>
+#include <stdlib.h>
 #include "gdb.h"
 
-int fact(int n)
-{volatile int __attribute__((unused)) tmp=n; // stack
- if (n>1)
-    return(fact(n-1)*n);
- else return(1); // 1!=1
+typedef uint16_t size_t;
+typedef uint32_t u32;
+
+static void u32_swap(void *a, void *b, int size)
+{
+	u32 t = *(u32 *)a;
+	*(u32 *)a = *(u32 *)b;
+	*(u32 *)b = t;
 }
+
+static void generic_swap(void *a, void *b, int size)
+{
+	char t;
+
+	do {
+		t = *(char *)a;
+		*(char *)a++ = *(char *)b;
+		*(char *)b++ = t;
+	} while (--size > 0);
+}
+
+/**
+ * sort - sort an array of elements
+ * @base: pointer to data to sort
+ * @num: number of elements
+ * @size: size of each element
+ * @cmp_func: pointer to comparison function
+ * @swap_func: pointer to swap function or NULL
+ *
+ * This function does a heapsort on the given array. You may provide a
+ * swap_func function optimized to your element type.
+ *
+ * Sorting time is O(n log n) both on average and worst-case. While
+ * qsort is about 20% faster on average, it suffers from exploitable
+ * O(n*n) worst-case behavior and extra memory requirements that make
+ * it less suitable for kernel use.
+ */
+
+void sort(void *base, size_t num, size_t size,
+		  int (*cmp_func)(const void *, const void *),
+		  void (*swap_func)(void *, void *, int size))
+{
+	/* pre-scale counters for performance */
+	int i = (num/2 - 1) * size, n = num * size, c, r;
+
+	if (!swap_func)
+		swap_func = (size == 4 ? u32_swap : generic_swap);
+
+	/* heapify */
+	for ( ; i >= 0; i -= size) {
+		for (r = i; r * 2 + size < n; r  = c) {
+			c = r * 2 + size;
+			if (c < n - size &&
+					cmp_func(base + c, base + c + size) < 0)
+				c += size;
+			if (cmp_func(base + r, base + c) >= 0)
+				break;
+			swap_func(base + r, base + c, size);
+		}
+	}
+
+	/* sort */
+	for (i = n - size; i > 0; i -= size) {
+		swap_func(base, base + i, size);
+		for (r = 0; r * 2 + size < i; r = c) {
+			c = r * 2 + size;
+			if (c < i - size &&
+					cmp_func(base + c, base + c + size) < 0)
+				c += size;
+			if (cmp_func(base + r, base + c) >= 0)
+				break;
+			swap_func(base + r, base + c, size);
+		}
+	}
+}
+
+static int cmpint(const void *a, const void *b)
+{
+	return *(int *)a - *(int *)b;
+}
+
+static int sort_test(void)
+{
+	int i, r = 1;
+	int a[10];
+
+	for (i = 0; i < 10; i++) {
+		r = (r * 725861) % 6599;
+		a[i] = r;
+	}
+
+	sort(a, 10, sizeof(int), cmpint, NULL);
+
+	return 0;
+}
+
 
 int main(void)
 {
- volatile int __attribute__((unused)) val=5,res;
- volatile __attribute__((unused)) static int val1=0x42,val2=0x55; // heap
- struct gdb_context ctx;
- gdb_init(&ctx);
- sei();
- while(1)
-    res=fact(val);
+	struct gdb_context ctx;
+	gdb_init(&ctx);
+
+	sei();
+
+	/* run sort test in loop */
+	while(1)
+		sort_test();
+
+	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -1,27 +1,19 @@
-/*
- * Sort algorithm and its test from linux kernel
- */
-#include <avr/interrupt.h>
-#include <stdlib.h>
-#include <avr/io.h>
-
+#include <avr/interrupt.h> // sei()
 #include "gdb.h"
 
 int fact(int n)
-{volatile int tmp=n;
+{volatile int __attribute__((unused)) tmp=n; // stack
  if (n>1)
     return(fact(n-1)*n);
  else return(1); // 1!=1
 }
 
-
 int main(void)
 {
- int val=5,res;
- volatile static int val1=0x42,val2=0x55;
+ volatile int __attribute__((unused)) val=5,res;
+ volatile __attribute__((unused)) static int val1=0x42,val2=0x55; // heap
  struct gdb_context ctx;
  gdb_init(&ctx);
- USBCON=0;
  sei();
  while(1)
     res=fact(val);

--- a/main.c
+++ b/main.c
@@ -3,115 +3,26 @@
  */
 #include <avr/interrupt.h>
 #include <stdlib.h>
+#include <avr/io.h>
+
 #include "gdb.h"
 
-typedef uint16_t size_t;
-typedef uint32_t u32;
-
-static void u32_swap(void *a, void *b, int size)
-{
-	u32 t = *(u32 *)a;
-	*(u32 *)a = *(u32 *)b;
-	*(u32 *)b = t;
-}
-
-static void generic_swap(void *a, void *b, int size)
-{
-	char t;
-
-	do {
-		t = *(char *)a;
-		*(char *)a++ = *(char *)b;
-		*(char *)b++ = t;
-	} while (--size > 0);
-}
-
-/**
- * sort - sort an array of elements
- * @base: pointer to data to sort
- * @num: number of elements
- * @size: size of each element
- * @cmp_func: pointer to comparison function
- * @swap_func: pointer to swap function or NULL
- *
- * This function does a heapsort on the given array. You may provide a
- * swap_func function optimized to your element type.
- *
- * Sorting time is O(n log n) both on average and worst-case. While
- * qsort is about 20% faster on average, it suffers from exploitable
- * O(n*n) worst-case behavior and extra memory requirements that make
- * it less suitable for kernel use.
- */
-
-void sort(void *base, size_t num, size_t size,
-		  int (*cmp_func)(const void *, const void *),
-		  void (*swap_func)(void *, void *, int size))
-{
-	/* pre-scale counters for performance */
-	int i = (num/2 - 1) * size, n = num * size, c, r;
-
-	if (!swap_func)
-		swap_func = (size == 4 ? u32_swap : generic_swap);
-
-	/* heapify */
-	for ( ; i >= 0; i -= size) {
-		for (r = i; r * 2 + size < n; r  = c) {
-			c = r * 2 + size;
-			if (c < n - size &&
-					cmp_func(base + c, base + c + size) < 0)
-				c += size;
-			if (cmp_func(base + r, base + c) >= 0)
-				break;
-			swap_func(base + r, base + c, size);
-		}
-	}
-
-	/* sort */
-	for (i = n - size; i > 0; i -= size) {
-		swap_func(base, base + i, size);
-		for (r = 0; r * 2 + size < i; r = c) {
-			c = r * 2 + size;
-			if (c < i - size &&
-					cmp_func(base + c, base + c + size) < 0)
-				c += size;
-			if (cmp_func(base + r, base + c) >= 0)
-				break;
-			swap_func(base + r, base + c, size);
-		}
-	}
-}
-
-static int cmpint(const void *a, const void *b)
-{
-	return *(int *)a - *(int *)b;
-}
-
-static int sort_test(void)
-{
-	int i, r = 1;
-	int a[10];
-
-	for (i = 0; i < 10; i++) {
-		r = (r * 725861) % 6599;
-		a[i] = r;
-	}
-
-	sort(a, 10, sizeof(int), cmpint, NULL);
-
-	return 0;
+int fact(int n)
+{volatile int tmp=n;
+ if (n>1)
+    return(fact(n-1)*n);
+ else return(1); // 1!=1
 }
 
 
 int main(void)
 {
-	struct gdb_context ctx;
-	gdb_init(&ctx);
-
-	sei();
-
-	/* run sort test in loop */
-	while(1)
-		sort_test();
-
-	return 0;
+ int val=5,res;
+ volatile static int val1=0x42,val2=0x55;
+ struct gdb_context ctx;
+ gdb_init(&ctx);
+ USBCON=0;
+ sei();
+ while(1)
+    res=fact(val);
 }


### PR DESCRIPTION
This pull request updates variables to match the Atmega32U4 UART and ISR naming convention. Tested as functional on an Olimexino32U4 board with a UART to TTL converter.